### PR TITLE
Refactor to use recent improvements in upstream project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ion-bazan/composer-diff": "dev-feature/web-refactor",
+        "ion-bazan/composer-diff": "^1.12",
         "composer/composer": "^2.8.8",
         "symfony/var-dumper": "^7.2.3",
         "twig/twig": "^3.20",

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         }
     ],
     "require": {
-        "ion-bazan/composer-diff": "^1.11",
+        "ion-bazan/composer-diff": "dev-feature/web-refactor",
         "composer/composer": "^2.8.8",
         "symfony/var-dumper": "^7.2.3",
         "twig/twig": "^3.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe9841cc2d4b667202e257348a454fac",
+    "content-hash": "9a886b9f1f00e6ce761f87c64cacc48c",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -646,16 +646,16 @@
         },
         {
             "name": "ion-bazan/composer-diff",
-            "version": "v1.11.0",
+            "version": "dev-feature/web-refactor",
             "source": {
                 "type": "git",
                 "url": "https://github.com/IonBazan/composer-diff.git",
-                "reference": "623a9a01412606e0ec5a035dfe05d4bc4b9103b5"
+                "reference": "f0dff281670dcf6bbe54844db01133db515e2fdf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/623a9a01412606e0ec5a035dfe05d4bc4b9103b5",
-                "reference": "623a9a01412606e0ec5a035dfe05d4bc4b9103b5",
+                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/f0dff281670dcf6bbe54844db01133db515e2fdf",
+                "reference": "f0dff281670dcf6bbe54844db01133db515e2fdf",
                 "shasum": ""
             },
             "require": {
@@ -707,7 +707,7 @@
             ],
             "support": {
                 "issues": "https://github.com/IonBazan/composer-diff/issues",
-                "source": "https://github.com/IonBazan/composer-diff/tree/v1.11.0"
+                "source": "https://github.com/IonBazan/composer-diff/tree/feature/web-refactor"
             },
             "funding": [
                 {
@@ -715,7 +715,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-02-06T07:23:48+00:00"
+            "time": "2025-04-09T17:55:29+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2639,7 +2639,9 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "ion-bazan/composer-diff": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/composer.lock
+++ b/composer.lock
@@ -650,12 +650,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/IonBazan/composer-diff.git",
-                "reference": "f0dff281670dcf6bbe54844db01133db515e2fdf"
+                "reference": "7692708316fe2df970e698e32827f9cbdeae8222"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/f0dff281670dcf6bbe54844db01133db515e2fdf",
-                "reference": "f0dff281670dcf6bbe54844db01133db515e2fdf",
+                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/7692708316fe2df970e698e32827f9cbdeae8222",
+                "reference": "7692708316fe2df970e698e32827f9cbdeae8222",
                 "shasum": ""
             },
             "require": {
@@ -715,7 +715,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-09T17:55:29+00:00"
+            "time": "2025-04-16T08:13:04+00:00"
         },
         {
             "name": "justinrainbow/json-schema",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9a886b9f1f00e6ce761f87c64cacc48c",
+    "content-hash": "8b5e3bd6bf6cb2cab3472e45d7749d61",
     "packages": [
         {
             "name": "composer/ca-bundle",
@@ -646,16 +646,16 @@
         },
         {
             "name": "ion-bazan/composer-diff",
-            "version": "dev-feature/web-refactor",
+            "version": "v1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/IonBazan/composer-diff.git",
-                "reference": "7692708316fe2df970e698e32827f9cbdeae8222"
+                "reference": "5eb28baa038045f5a161c958847e6d9920c79191"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/7692708316fe2df970e698e32827f9cbdeae8222",
-                "reference": "7692708316fe2df970e698e32827f9cbdeae8222",
+                "url": "https://api.github.com/repos/IonBazan/composer-diff/zipball/5eb28baa038045f5a161c958847e6d9920c79191",
+                "reference": "5eb28baa038045f5a161c958847e6d9920c79191",
                 "shasum": ""
             },
             "require": {
@@ -707,7 +707,7 @@
             ],
             "support": {
                 "issues": "https://github.com/IonBazan/composer-diff/issues",
-                "source": "https://github.com/IonBazan/composer-diff/tree/feature/web-refactor"
+                "source": "https://github.com/IonBazan/composer-diff/tree/v1.12.0"
             },
             "funding": [
                 {
@@ -715,7 +715,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-04-16T08:13:04+00:00"
+            "time": "2025-04-18T14:19:55+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
@@ -2639,9 +2639,7 @@
     "packages-dev": [],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "ion-bazan/composer-diff": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {},

--- a/src/Comparator.php
+++ b/src/Comparator.php
@@ -44,19 +44,12 @@ class Comparator
             $this->packageDiff->loadPackagesFromArray($newLock, true, false)
         );
 
-        $generators = new GeneratorContainer([]);
-
         $output = new BufferedOutput();
-        $formatter = new JsonFormatter($output, $generators);
-        $formatter->render($prodOperations, $devOperations, true, true);
-        $array = json_decode($output->fetch(), true, 512, JSON_THROW_ON_ERROR);
-
-        $output = new BufferedOutput();
-        $formatter = new MarkdownTableFormatter($output, $generators);
+        $formatter = new MarkdownTableFormatter($output);
         $formatter->render($prodOperations, $devOperations, true, true);
         $markdown = $output->fetch();
 
-        return new Diff($array, $markdown);
+        return new Diff($prodOperations, $devOperations, $markdown);
     }
 
     private function getLockArray(string $composerLock, string $path): array

--- a/src/Diff.php
+++ b/src/Diff.php
@@ -2,10 +2,13 @@
 
 namespace App;
 
+use IonBazan\ComposerDiff\Diff\DiffEntries;
+
 final readonly class Diff
 {
     public function __construct(
-        public array $array,
+        public DiffEntries $prodEntries,
+        public DiffEntries $devEntries,
         public string $markdown,
     ) {}
 }

--- a/templates/diff.html.twig
+++ b/templates/diff.html.twig
@@ -1,5 +1,5 @@
-{% macro render(title, packages) %}
-    {% if packages %}
+{% macro render(title, entries) %}
+    {% if entries %}
         <div class="mt-4">
             <h3>
                 <i class="fas {% if title in 'Dev' %}fa-wrench{% else %}fa-box{% endif %} me-2"></i>
@@ -18,31 +18,27 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for package in packages %}
-                            {% set isDowngrade = package.operation == 'downgrade' %}
-                            {% set isInstall = package.operation == 'install' %}
-                            {% set isRemove = package.operation == 'remove' %}
-                            {% set isUpgrade = package.operation == 'upgrade' %}
+                        {% for entry in entries %}
                             <tr>
                                 <td>
-                                    <a href="{{ package.link }}" target="_blank">
+                                    <a href="{{ entry.projectUrl }}" target="_blank">
                                         <i class="fas fa-external-link-alt me-1"></i>
-                                        {{ package.name }}
+                                        {{ entry.package.name }}
                                     </a>
                                 </td>
-                                <td class="operation-{{ package.operation }}"
+                                <td class="operation-{{ entry.type }}"
                                 >
-                                    {% if isDowngrade %}<i class="fas fa-arrow-down me-1"></i> {% endif %}
-                                    {% if isInstall %}<i class="fas fa-plus-circle me-1"></i> {% endif %}
-                                    {% if isRemove %}<i class="fas fa-minus-circle me-1"></i> {% endif %}
-                                    {% if isUpgrade %}<i class="fas fa-arrow-up me-1"></i> {% endif %}
-                                    {{ package.operation|title }}
+                                    {% if entry.isDowngrade %}<i class="fas fa-arrow-down me-1"></i> {% endif %}
+                                    {% if entry.isInstall %}<i class="fas fa-plus-circle me-1"></i> {% endif %}
+                                    {% if entry.isRemove %}<i class="fas fa-minus-circle me-1"></i> {% endif %}
+                                    {% if entry.isUpgrade %}<i class="fas fa-arrow-up me-1"></i> {% endif %}
+                                    {{ entry.type|title }}
                                 </td>
-                                <td>{{ package.version_base }}</td>
-                                <td>{{ package.version_target }}</td>
+                                <td>{{ entry.baseVersion }}</td>
+                                <td>{{ entry.targetVersion }}</td>
                                 <td>
-                                    {% if isUpgrade or isDowngrade %}
-                                        <a href="{{ package.compare }}" class="compare-link" target="_blank">
+                                    {% if entry.isUpgrade or entry.isDowngrade %}
+                                        <a href="{{ entry.url }}" class="compare-link" target="_blank">
                                             <i class="fas fa-code-branch me-1"></i>View diff
                                         </a>
                                     {% else %}
@@ -50,7 +46,7 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    <span class="badge bg-light text-dark">{{ package.license }}</span>
+                                    <span class="badge bg-light text-dark">{{ entry.licenses|join(', ')|default }}</span>
                                 </td>
                             </tr>
                         {% endfor %}
@@ -68,5 +64,5 @@
 {% endif %}
 
 
-{{ _self.render('Packages', diff['packages']) }}
-{{ _self.render('Dev Packages', diff['packages-dev']) }}
+{{ _self.render('Packages', diff.prodEntries) }}
+{{ _self.render('Dev Packages', diff.devEntries) }}

--- a/templates/diff.html.twig
+++ b/templates/diff.html.twig
@@ -46,7 +46,7 @@
                                     {% endif %}
                                 </td>
                                 <td>
-                                    <span class="badge bg-light text-dark">{{ entry.licenses|join(', ')|default }}</span>
+                                    <span class="badge bg-light text-dark">{{ entry.licenses|join(', ') }}</span>
                                 </td>
                             </tr>
                         {% endfor %}
@@ -57,7 +57,7 @@
     {% endif %}
 {% endmacro %}
 
-{% if not diff['packages'] and not diff['packages-dev'] %}
+{% if not diff.prodEntries and not diff.devEntries %}
     <div class="alert alert-warning mt-2" role="alert">
         Both <code>composer.lock</code> looks the same
     </div>

--- a/templates/index.html.twig
+++ b/templates/index.html.twig
@@ -256,7 +256,7 @@
                     <h2>
                         <i class="fas fa-list me-2"></i>Comparison Results
                     </h2>
-                    {{ include('diff.html.twig', {diff: result.diff.array, with_context: false}) }}
+                    {{ include('diff.html.twig', {diff: result.diff, with_context: false}) }}
                 </div>
                 <div class="diff-section">
                     <h2>


### PR DESCRIPTION
I've made some changes to https://github.com/IonBazan/composer-diff/tree/feature/web-refactor making it easier to compare the lock files from memory (after json_decode).

These changes here are using the branch directly - let me know if that works for you and I'll try to tag it once it's stable.